### PR TITLE
daemon: deprecated --log-error -> --log-level=error

### DIFF
--- a/daemon/transmission-daemon.service
+++ b/daemon/transmission-daemon.service
@@ -6,7 +6,7 @@ After=network-online.target
 [Service]
 User=transmission
 Type=notify
-ExecStart=/usr/bin/transmission-daemon -f --log-error
+ExecStart=/usr/bin/transmission-daemon -f --log-level=error
 ExecReload=/bin/kill -s HUP $MAINPID
 NoNewPrivileges=true
 MemoryDenyWriteExecute=true

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -798,7 +798,7 @@ static void sessionSetImpl(struct init_data* const data)
     if (tr_variantDictFindStrView(settings, TR_KEY_umask, &sv))
     {
         /* Read a umask as a string representing an octal number. */
-        session->umask = tr_parseNum<mode_t>(sv, 8).value_or(DefaultUmask);
+        session->umask = static_cast<mode_t>(tr_parseNum<uint32_t>(sv, 8).value_or(DefaultUmask));
         umask(session->umask);
     }
     else if (tr_variantDictFindInt(settings, TR_KEY_umask, &i))

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -1416,12 +1416,12 @@ template<typename T, std::enable_if_t<std::is_integral<T>::value, bool>>
 #endif // #if defined(__GNUC__) && !__has_include(<charconv>)
 
 template std::optional<int64_t> tr_parseNum(std::string_view& sv, int base);
-template std::optional<int> tr_parseNum(std::string_view& sv, int base);
-template std::optional<size_t> tr_parseNum(std::string_view& sv, int base);
+template std::optional<int32_t> tr_parseNum(std::string_view& sv, int base);
+template std::optional<int8_t> tr_parseNum(std::string_view& sv, int base);
 
-#ifndef _WIN32
-template std::optional<mode_t> tr_parseNum(std::string_view& sv, int base);
-#endif
+template std::optional<uint64_t> tr_parseNum(std::string_view& sv, int base);
+template std::optional<uint32_t> tr_parseNum(std::string_view& sv, int base);
+template std::optional<uint8_t> tr_parseNum(std::string_view& sv, int base);
 
 template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool>>
 [[nodiscard]] std::optional<T> tr_parseNum(std::string_view& sv)


### PR DESCRIPTION
On startup the system.d service warns 
```
Jun 05 05:07:40 schwarzschild transmission-daemon[15562]: WARN: --log-error is deprecated. Use --log-level=error
```